### PR TITLE
test: Replication race confition

### DIFF
--- a/packages/automerge-repo/test/subduction/Race.subscriber-before-publisher.test.ts
+++ b/packages/automerge-repo/test/subduction/Race.subscriber-before-publisher.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Reproduces the "subscriber-before-publisher" race in `SubductionSource`.
+ *
+ * Topology: three repos over in-memory `MessageChannel`s.
+ *
+ *     ┌──────────┐          ┌──────────┐          ┌──────────┐
+ *     │  peer A  │◀───mc───▶│  peer S  │◀───mc───▶│  peer B  │
+ *     │publisher │          │  server  │          │subscriber│
+ *     │ "connect"│          │ "accept" │          │ "connect"│
+ *     └──────────┘          └──────────┘          └──────────┘
+ *
+ * Bug: when peer B calls `repo.find(url)` for a document that peer A has
+ * just created locally but has not yet pushed to peer S,
+ * `SubductionSource.#recomputeEntry` / `#loadBlobsAndTransition` transitions
+ * peer B's `DocumentQuery` to terminal `"unavailable"` and `repo.find`
+ * rejects with `Error: Document <id> is unavailable` — before peer A's
+ * throttled `addCommit` + `syncWithAllPeers(..., true)` has a chance to
+ * propagate the commits via peer S.
+ *
+ * Marked `it.fails` because on the current `subduction` branch this test
+ * body deterministically throws. Remove `.fails` once a fix lands
+ * (candidate fixes in `source.ts`:
+ *   1. new `pushDoc` primitive awaited by the publisher before the
+ *      subscriber `find`s;
+ *   2. `#loadBlobsAndTransition` grace window on a never-delivered
+ *      sedimentree instead of a terminal `sourceUnavailable` on the first
+ *      empty sync;
+ *   3. ensure `addCommit` has been flushed + synced before the first
+ *      subscriber-initiated `#doSync` can observe an empty remote.)
+ */
+
+import { describe, it, expect, afterEach, vi } from "vitest"
+import { MessageChannelNetworkAdapter } from "../../../automerge-repo-network-messagechannel/src/index.js"
+import { Repo } from "../../src/Repo.js"
+import { DummyStorageAdapter } from "../../src/helpers/DummyStorageAdapter.js"
+import { type PeerId } from "../../src/types.js"
+import { pause } from "../../src/helpers/pause.js"
+
+describe("SubductionSource subscriber-before-publisher race", () => {
+  const cleanups: Array<() => Promise<void> | void> = []
+
+  afterEach(async () => {
+    for (const cleanup of cleanups.reverse()) {
+      try {
+        await cleanup()
+      } catch {
+        // best-effort teardown
+      }
+    }
+    cleanups.length = 0
+  })
+
+  function openThreeRepos() {
+    const channelAS = new MessageChannel()
+    const channelBS = new MessageChannel()
+    cleanups.push(() => channelAS.port1.close())
+    cleanups.push(() => channelBS.port1.close())
+
+    const serviceName = "race-test"
+
+    const repoS = new Repo({
+      peerId: "S" as PeerId,
+      storage: new DummyStorageAdapter(),
+      network: [],
+      subductionAdapters: [
+        {
+          adapter: new MessageChannelNetworkAdapter(channelAS.port2),
+          serviceName,
+          role: "accept",
+        },
+        {
+          adapter: new MessageChannelNetworkAdapter(channelBS.port2),
+          serviceName,
+          role: "accept",
+        },
+      ],
+      sharePolicy: async () => true,
+    })
+
+    const repoA = new Repo({
+      peerId: "A" as PeerId,
+      storage: new DummyStorageAdapter(),
+      network: [],
+      subductionAdapters: [
+        {
+          adapter: new MessageChannelNetworkAdapter(channelAS.port1),
+          serviceName,
+        },
+      ],
+      sharePolicy: async () => true,
+    })
+
+    const repoB = new Repo({
+      peerId: "B" as PeerId,
+      storage: new DummyStorageAdapter(),
+      network: [],
+      subductionAdapters: [
+        {
+          adapter: new MessageChannelNetworkAdapter(channelBS.port1),
+          serviceName,
+        },
+      ],
+      sharePolicy: async () => true,
+    })
+
+    cleanups.push(() => repoA.shutdown())
+    cleanups.push(() => repoB.shutdown())
+    cleanups.push(() => repoS.shutdown())
+
+    return { repoA, repoB, repoS }
+  }
+
+  it(
+    "peer B finds a doc peer A just created — should resolve, today rejects unavailable",
+    async () => {
+      const { repoA, repoB } = openThreeRepos()
+
+      // Let the two handshakes (A↔S, B↔S) settle so authentication state
+      // is stable when peer A creates the doc.
+      await pause(250)
+
+      // Publisher creates + mutates. The change is in peer A's in-memory
+      // `DocHandle`, but `throttledSave` debounces `addCommit` by 100ms,
+      // so peer S has zero blobs for this sedimentree at the moment
+      // peer B runs its first `syncWithAllPeers` round.
+      const docA = repoA.create<{ foo: number }>()
+      docA.change(d => {
+        d.foo = 1
+      })
+
+      // Subscriber asks immediately — the exact pattern a real client uses
+      // after reload: "here's the URL, hand me the content."
+      //
+      // We use `findWithProgress` rather than `find` because `find`'s
+      // promise rejects terminally when the query passes through
+      // `"unavailable"` (same rejection logic in `DocumentQuery.whenReady`
+      // / `DocumentProgress.whenReady`). A `DocumentQuery` itself CAN
+      // recover `unavailable → loading → ready` via
+      // `SubductionSource.#handleDataFound` → `sourcePending`, so polling
+      // `peek()` observes the recovery — when it happens.
+      //
+      // Expected: peer A's throttled save pushes blobs to peer S, peer S
+      // forwards to peer B via subduction's subscription, peer B's query
+      // reaches `"ready"` with `{ foo: 1 }`.
+      //
+      // Actual (current `subduction` branch): `#loadBlobsAndTransition`
+      // marks peer B's query `"unavailable"` before peer A's 100ms
+      // throttle fires, and the recovery does not land within the
+      // timeout — `vi.waitFor` below throws, failing the test.
+      const progressB = repoB.findWithProgress<{ foo: number }>(docA.url)
+      await vi.waitFor(
+        () => {
+          const s = progressB.peek().state
+          if (s !== "ready") throw new Error(`state=${s}`)
+        },
+        { timeout: 3000, interval: 25 }
+      )
+      const ready = progressB.peek()
+      if (ready.state !== "ready") throw new Error("unreachable")
+      expect(ready.handle.doc()).toEqual({ foo: 1 })
+    },
+    10_000
+  )
+})


### PR DESCRIPTION
- **Add GitHub issue template to guide contributions (#548)**
- **Bump svelte from 5.37.3 to 5.51.5 (#574)**
- **Bump svelte from 5.51.5 to 5.53.5 (#575)**
- **Fix some storage bugs**
- **trigger v2.5.4-alpha.0 release**
- **v2.5.4-alpha.0**
- **trigger v2.5.4 release**
- **v2.5.4**
- **solidjs primitives: add a lighter coarse-grained primitive for when you dont need a store (#579)**
- **Bump happy-dom from 20.0.10 to 20.8.8 (#582)**
- **trigger v2.5.5 release (#585)**
- **v2.5.5**
- **Read-atomic/crash-atomic NodeFSStorageAdapter**
- **rerefactor**
- **Add subduction**
- **Port flake.nix**
- **Imprpve throttle**
- **Self-healing on failure**
- **Periodic sync**
- **Port over final features**
- **Fomratter**
- **Use isomorphic-ws and pruning->pruned**
- **Add persistent signer**
- **Add retry logic**
- **Batched IDB access**
- **WIP get examples working**
- **Fix shared worker not loading**
- **Ephemera working!**
- **All have tag: subudction**
- **Update the .npmrc**
- **Improve DB perf for SDN**
- **Get the SharedWorker to load first time**
- **Fix all but one test**
- **bump to -subduction.7**
- **Add batching API**
- **Add NetworkAdapterInterface.state to observe changes in adapter stat**
- **Add NetworkAdapter based connections to subduction**
- **Bump to subduction 0.6.3 (#588)**
- **Fix `subductionjs` infinite loop (#586)**
- **Add `SubductionPolicy` support (#587)**
- **Bump package versions**
- **Make publish branch subductionjs**
- **(Hopefully) fix Subduction HOL-blocking (#590)**
- **Bump package numbers**
- **subductionjs: clean shutdown & turn down logging (#591)**
- **Bump to -subduction.10**
- **Retry failed syncs on SubductionSource on shareConfigChanged()**
- **Added shareConfigChanged() to DocumentSource**
- **Bump to -subduction.11**
- **Bump all to .11**
- **Actually bump all to .11**
- **Bump to .12**
- **Remove both(!) periodic sync mechanisms**
- **Concat loadIncremental (#596)**
- **Don't manually call `free` (#599)**
- **Add `saveBatch` and safer write order for Subduction bridge (#602)**
- **Bump to -subduction.13**
- **Fully hydrate if there are any adapters (#603)**
- **Bump to -subduction.14**
- **test: Add test for "subscriber-before-publisher" race condition in SubductionSource**
